### PR TITLE
Add reporting support for run-workers

### DIFF
--- a/bin/codecept.js
+++ b/bin/codecept.js
@@ -131,6 +131,8 @@ program.command('run-workers <workers>')
   .option('--tests', 'run only JS test files and skip features')
   .option('--profile [value]', 'configuration profile to be used')
   .option('-p, --plugins <k=v,k2=v2,...>', 'enable plugins, comma-separated')
+  .option('-O, --reporter-options <k=v,k2=v2,...>', 'reporter-specific options')
+  .option('-R, --reporter <name>', 'specify the reporter to use')
   .action(require('../lib/command/run-workers'));
 
 program.command('run-multiple [suites...]')


### PR DESCRIPTION
Add reporting support for run-workers command. 
Can be used to get junit reports.
Example command:
npx codeceptjs run-workers 2 --reporter mocha-junit-reporter

- Resolves #issueId [1938](https://github.com/codeceptjs/CodeceptJS/issues/1938)
